### PR TITLE
filter-bot-events before sending mail

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -66,7 +66,7 @@ export class AppModule implements OnApplicationShutdown {
       userId: string,
       lookupData: LookUpEntry[],
     ): string[] => {
-      if (isTestMode) {
+      if (isTestMode || userId === process.env.MATRIX_BOT_USER_ID) {
         return [process.env.TEST_EMAIL_RECIPIENT];
       }
 


### PR DESCRIPTION
One-liner PR which will redirect mails triggered by events of the bot account to the TEST_EMAIL_RECIPIENT instead of searching for that address in the lookup file, in which that accounts isn't included. 